### PR TITLE
added retry logic for 409 error code

### DIFF
--- a/cosmos/job/drm/drm_gke.py
+++ b/cosmos/job/drm/drm_gke.py
@@ -100,25 +100,24 @@ def _kube_label(string, strict=False):
 def _k8s_api_wrapper(*codes_to_ignore, logger=None):
     def decorator(func):
         def _should_retry(e):
-            retry_cond = (
-                (isinstance(e, ApiException) and (
-                    # Retry on all 50X errors
-                    e.status > 500 or
-                    # Retry on response truncation. This happens sometimes
-                    # when fetching logs.
-                    (
-                        e.status == 500 and
-                        isinstance(e.body, bytes) and
-                        b'EOF' in e.body
-                    ) or
-                    # Retry on conflict with current cluster state. Workaround for:
-                    # HTTP response headers: <CIMultiDictProxy('Audit-Id': '01fab989-6ce8-439a-bc55-b61145a0cf36', 'Content-Type': 'application/json', 'Date': 'Sat, 11 Jan 2020 17:09:22 GMT', 'Content-Length': '342')>HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Operation cannot be fulfilled on resourcequotas \"gke-resource-quotas\": the object has been modified; please apply your changes to the latest version and try again","reason":"Conflict","details":{"name":"gke-resource-quotas","kind":"resourcequotas"},"code":409}
-                    # TODO (jeev): This is a bandaid fix. We need a more reliable
-                    #  solution.
-                    e.status == 409
-                )) or
-                isinstance(e, TimeoutError)
-            )
+            # Retry on response truncation. This happens sometimes when fetching logs.
+            is_response_truncated = (e.status == 500 and isinstance(e.body, bytes) and b'EOF' in e.body)
+            # Retry on conflict with current cluster state. Workaround for:
+            # HTTP response headers:
+            # <CIMultiDictProxy('Audit-Id': '01fab989-6ce8-439a-bc55-b61145a0cf36', 'Content-Type': 'application/json',
+            # 'Date': 'Sat, 11 Jan 2020 17:09:22 GMT', 'Content-Length': '342')>HTTP
+            # response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
+            # "message":"Operation cannot be fulfilled on resourcequotas \"gke-resource-quotas\": the object has been modified;
+            # please apply your changes to the latest version and try again","reason":"Conflict","details":{"name":"gke-resource-quotas","kind":"resourcequotas"},"code":409}
+            # TODO (jeev): This is a bandaid fix. We need a more reliable
+            #  solution.
+            is_gke_quota_conflict = (e.status == 409)
+            # Retry on all 50X errors
+            is_50X_error = e.status > 500
+            is_known_api_exception = (isinstance(e, ApiException) and
+                                      (is_50X_error or is_response_truncated or is_gke_quota_conflict)
+                                      )
+            retry_cond = (is_known_api_exception or isinstance(e, TimeoutError))
             if retry_cond:
                 if logger is not None:
                     logger.warning(f'Retrying API call due to error: {str(e)}')

--- a/cosmos/job/drm/drm_gke.py
+++ b/cosmos/job/drm/drm_gke.py
@@ -102,6 +102,7 @@ def _k8s_api_wrapper(*codes_to_ignore, logger=None):
         def _should_retry(e):
             # Retry on response truncation. This happens sometimes when fetching logs.
             is_response_truncated = (e.status == 500 and isinstance(e.body, bytes) and b'EOF' in e.body)
+
             # Retry on conflict with current cluster state. Workaround for:
             # HTTP response headers:
             # <CIMultiDictProxy('Audit-Id': '01fab989-6ce8-439a-bc55-b61145a0cf36', 'Content-Type': 'application/json',
@@ -112,6 +113,7 @@ def _k8s_api_wrapper(*codes_to_ignore, logger=None):
             # TODO (jeev): This is a bandaid fix. We need a more reliable
             #  solution.
             is_gke_quota_conflict = (e.status == 409)
+
             # Retry on all 50X errors
             is_50X_error = e.status > 500
             is_known_api_exception = (isinstance(e, ApiException) and

--- a/cosmos/job/drm/drm_gke.py
+++ b/cosmos/job/drm/drm_gke.py
@@ -110,7 +110,12 @@ def _k8s_api_wrapper(*codes_to_ignore, logger=None):
                         e.status == 500 and
                         isinstance(e.body, bytes) and
                         b'EOF' in e.body
-                    )
+                    ) or
+                    # Retry on conflict with current cluster state. Workaround for:
+                    # HTTP response headers: <CIMultiDictProxy('Audit-Id': '01fab989-6ce8-439a-bc55-b61145a0cf36', 'Content-Type': 'application/json', 'Date': 'Sat, 11 Jan 2020 17:09:22 GMT', 'Content-Length': '342')>HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Operation cannot be fulfilled on resourcequotas \"gke-resource-quotas\": the object has been modified; please apply your changes to the latest version and try again","reason":"Conflict","details":{"name":"gke-resource-quotas","kind":"resourcequotas"},"code":409}
+                    # TODO (jeev): This is a bandaid fix. We need a more reliable
+                    #  solution.
+                    e.status == 409
                 )) or
                 isinstance(e, TimeoutError)
             )


### PR DESCRIPTION
**What does this PR do?**

When we attempt to submit more than 1000 jobs, we are encountering issue with quota exceed error with following error message 
```
Reason: Conflict
HTTP response headers: HTTPHeaderDict({'Audit-Id': '25cace66-8e6e-4894-bdc2-0c2b146b2480', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Date': 'Mon, 05 Oct 2020 20:34:11 GMT', 'Content-Length': '342'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Operation cannot be fulfilled on resourcequotas \"gke-resource-quotas\": the object has been modified; please apply your changes to the latest version and try again","reason":"Conflict","details":{"name":"gke-resource-quotas","kind":"resourcequotas"},"code":409}
```
@jeevb already added a patch fix for this in daikon and i have taken that fix from there.
This fix is brought from here 
https://github.com/freenome/daikon/blob/3325ead58dcee01dfcec821991e6e67495d47d4a/daikon/utils/kubernetes.py#L48

I want to know if this fix propagate downstream to update all the Docker images or if we need to manually trigger builds for other containers, such as `dev-tools`, `balrog-base` ...etc  

